### PR TITLE
feat: manually expand `~` and `$HOME` for custom config file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Add this to `~/.config/yazi/init.lua`:
 require("starship"):setup()
 ```
 
-If you wish to define a custom config file for `starship` to use, you can pass in an _absolute_ path
+If you wish to define a custom config file for `starship` to use, you can pass in a path
 to the setup function like this:
 
 ```lua


### PR DESCRIPTION
This removes the requirement for an absolute path for those cases, but note that the expansions are hard-coded and only `~` and `$HOME` are currently supported. If people need any other variables, feel free to make a PR or just lmk. More importantly, if someone knows a better way to do this, please do share as I don't spend all that much time working on `Yazi` plugins or with Lua in general.