### PR TITLE
feat: remove deprecation warning for nightly yazi users

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -61,7 +61,12 @@ return {
         ps.sub("tab", callback)
     end,
 
-    entry = function(_, args)
+    entry = function(_, job_or_args)
+        -- yazi 2024-11-29 changed the way arguments are passed to the plugin
+        -- entry point. They were moved inside {args = {...}}. If the user is using
+        -- a version before this change, they can use the old implementation.
+        -- https://github.com/sxyazi/yazi/pull/1966
+        local args = job_or_args.args or job_or_args
         local command = Command("starship"):arg("prompt"):cwd(args[1]):env("STARSHIP_SHELL", "")
 
         -- Point to custom starship config


### PR DESCRIPTION
Issue
=====

The nightly version of yazi has changed the way arguments are passed to the plugin entry point. Previously they were a table that contained the arguments, but they were moved inside {args = {...}}.

If the user is using a nightly version of yazi, they will see a deprecation warning.

https://github.com/sxyazi/yazi/pull/1966

![image](https://github.com/user-attachments/assets/ced5fbfc-0ef3-4ba3-82bc-e532b5cc26c5)


Solution
========

This change removes the warning and supports both versions.