### PR TITLE
feat: inherit stdin when running starship

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -67,7 +67,11 @@ return {
         -- a version before this change, they can use the old implementation.
         -- https://github.com/sxyazi/yazi/pull/1966
         local args = job_or_args.args or job_or_args
-        local command = Command("starship"):arg("prompt"):cwd(args[1]):env("STARSHIP_SHELL", "")
+        local command = Command("starship")
+            :arg("prompt")
+            :stdin(Command.INHERIT)
+            :cwd(args[1])
+            :env("STARSHIP_SHELL", "")
 
         -- Point to custom starship config
         local config_file = get_config_file()


### PR DESCRIPTION
Closes #15

Allows starship to auto detect the terminal width by inheriting stdin from yazi.