### PR TITLE
feat: support main.lua in nightly yazi

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1,0 +1,1 @@
+init.lua


### PR DESCRIPTION
yazi has changed the main entry point of plugins to `main.lua` instead of `init.lua` here https://github.com/sxyazi/yazi/pull/2168

I applied a symbolic link between these that might be able to support both versions, leaving the current one untouched until a breaking change is made.