### PR TITLE
feat: support yazi 25.2.7

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,5 @@
+--- @since 25.2.7
+
 local save = ya.sync(function(st, cwd, output)
     if cx.active.current.cwd == Url(cwd) then
         st.output = output
@@ -49,10 +51,20 @@ return {
             local cwd = cx.active.current.cwd
             if st.cwd ~= cwd then
                 st.cwd = cwd
-                ya.manager_emit("plugin", {
-                    st._id,
-                    args = ya.quote(tostring(cwd), true),
-                })
+
+                if ya.confirm then
+                    -- >= yazi 25.2.7
+                    ya.manager_emit("plugin", {
+                        st._id,
+                        ya.quote(tostring(cwd), true),
+                    })
+                else
+                    -- < yazi 25.2.7
+                    ya.manager_emit("plugin", {
+                        st._id,
+                        args = ya.quote(tostring(cwd), true),
+                    })
+                end
             end
         end
 


### PR DESCRIPTION
Issue
=====

In yazi 25.2.7, loading the plugin will display a deprecation message.

> The `args` parameter of the `plugin` command has been deprecated.
> Please use the second positional argument of `plugin` instead. For
> example, replace `plugin test --args=foobar` with `plugin test foobar`,
> for your `plugin {}` command. See #2299 for more information:
> https://github.com/sxyazi/yazi/pull/2299

Source code for the message for reference:
https://github.com/sxyazi/yazi/pull/2299/files#diff-12c9a1618a93a5c77e0fb35e602178f0c266b8e4a43d0d578a6aa5e63f5b3c79R33

![image](https://github.com/user-attachments/assets/f139023a-d23d-4d25-a96a-042686b81823)

Solution
========

The deprecation message is confusing because it's aimed at end users, not plugin developers. It seems to go away if we remove the `args` key when emitting the `plugin` event.