### PR TITLE
fix: update prompt even when search is active

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -2,14 +2,12 @@
 
 -- For development
 --[[ local function notify(message) ]]
---[[     ya.notify({ title = "Starship", content = message, timeout = 5 }) ]]
+--[[     ya.notify({ title = "Starship", content = message, timeout = 3 }) ]]
 --[[ end ]]
 
-local save = ya.sync(function(st, cwd, output)
-    if cx.active.current.cwd == Url(cwd) then
-        st.output = output
-        ya.render()
-    end
+local save = ya.sync(function(st, _cwd, output)
+    st.output = output
+    ya.render()
 end)
 
 -- Helper function for accessing the `config_file` state variable


### PR DESCRIPTION
Closes #21 

@blackdaemon, if you have time would you mind checking if this fixes the issue for you (and doesn't break anything else). Otherwise just let me know, no worries though.