### PR TITLE
fix: use new `ya.emit` if available

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+  "runtime.version": "Lua 5.4",
+  "workspace.library": [
+    "~/.config/yazi/plugins/types.yazi/"
+  ]
+}

--- a/main.lua
+++ b/main.lua
@@ -89,7 +89,10 @@ return {
             if st.cwd ~= cwd then
                 st.cwd = cwd
 
-                ya.manager_emit("plugin", {
+                -- `ya.emit` as of 25.5.28
+                local emit = ya.emit or ya.manager_emit
+
+                emit("plugin", {
                     st._id,
                     ya.quote(tostring(cwd), true),
                 })


### PR DESCRIPTION
The new `v25.5.28` has deprecated `ya.manager_emit`, so use `ya.emit` if available and fallback to the old one to continue support for `v25.4.8`