### PR TITLE
fix: avoid deprecation warning for `ya.render` on `Yazi` with the latest changes

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -7,7 +7,9 @@
 
 local save = ya.sync(function(st, _cwd, output)
     st.output = output
-    ya.render()
+    -- Support for versions later than v25.5.31 (not yet a full release as of writing this comment)
+    local render = ui.render or ya.render
+    render()
 end)
 
 -- Helper function for accessing the `config_file` state variable


### PR DESCRIPTION
Closes #30