### PR TITLE
fix: displaying cwd of latest tab when opening multiple yazi tabs

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -113,6 +113,7 @@ return {
             :stdin(Command.INHERIT)
             :cwd(args[1])
             :env("STARSHIP_SHELL", "")
+            :env("PWD", args[1])
 
         -- Point to custom starship config
         local config_file = get_config_file()


### PR DESCRIPTION
**Issue:**

When opening yazi with multiple tabs, the plugin seems to initially display the cwd of the last tab.

Reproduction:

```sh
yazi $(pwd) /tmp
```

**Solution:**

Set the `PWD` environment variable as suggested in the issue below - it seems to work around the problem.

Closes https://github.com/Rolv-Apneseth/starship.yazi/issues/32